### PR TITLE
fix provider version and deprecated vpc_id usage

### DIFF
--- a/examples/vpc/highly-available/main.tf
+++ b/examples/vpc/highly-available/main.tf
@@ -13,3 +13,8 @@ module "vpc" {
   redis_at_rest_encryption_enabled = "${var.redis_at_rest_encryption_enabled}"
   redis_transit_encryption_enabled = "${var.redis_transit_encryption_enabled}"
 }
+
+provider "aws" {
+  version = "1.60.0"
+}
+  

--- a/examples/vpc/simple/main.tf
+++ b/examples/vpc/simple/main.tf
@@ -4,3 +4,7 @@ module "vpc" {
   aws_key_name     = "${var.project_name}"
   aws_key_location = "${file(var.aws_key_location)}"
 }
+
+provider "aws" {
+  version = "1.60.0"
+}

--- a/vpc/nat.tf
+++ b/vpc/nat.tf
@@ -108,13 +108,6 @@ resource "aws_security_group" "nat" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   
-  egress {
-    from_port   = 32768
-    to_port     = 65535
-    protocol    = "udp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   lifecycle = {
     create_before_destroy = true
   }

--- a/vpc/nat.tf
+++ b/vpc/nat.tf
@@ -107,6 +107,13 @@ resource "aws_security_group" "nat" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  
+  egress {
+    from_port   = 32768
+    to_port     = 65535
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   lifecycle = {
     create_before_destroy = true

--- a/vpc/rds.tf
+++ b/vpc/rds.tf
@@ -61,6 +61,8 @@ module "db" {
   maintenance_window     = "Mon:03:00-Mon:06:00"
   backup_window          = "00:00-03:00"
 
+  allow_major_version_upgrade = "${var.database_allow_major_version_upgrade}"
+
   # disable backups to create DB faster
   # must be enabled to support read replicas
   backup_retention_period = "${var.database_backup_retention_period}"

--- a/vpc/route53.tf
+++ b/vpc/route53.tf
@@ -1,6 +1,8 @@
 resource "aws_route53_zone" "internal" {
   name   = "internal"
-  vpc_id = "${module.vpc.vpc_id}"
+  vpc {
+    vpc_id = "${module.vpc.vpc_id}"
+  }
 }
 
 resource "aws_route53_record" "internal-ns" {

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -90,7 +90,7 @@ variable "database_multi_az" {
   default     = "false"
 }
 
-variable "allow_major_version_upgrade" {
+variable "database_allow_major_version_upgrade" {
   description = "Allow major version upgrades"
   default     = "false"
 }

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -90,6 +90,11 @@ variable "database_multi_az" {
   default     = "false"
 }
 
+variable "allow_major_version_upgrade" {
+  description = "Allow major version upgrades"
+  default     = "false"
+}
+
 // ElastiCache
 
 variable "redis_engine_version" {


### PR DESCRIPTION
terraform aws provider 2.0 causes the usage of

```
vpc_id = "${module.vpc.vpc_id}"
```

to actually halt execution.

Furthermore, you get something like the following as well if you use provider version 2.0. Not sure if it's a problem on our end or on terraform provider end but it definitely threw a n00b like me for a loop:

```
module.vpc.aws_route53_record.postgres: Still creating... (40s elapsed)
module.vpc.aws_route53_record.redis: Still creating... (10s elapsed)
module.vpc.aws_route53_record.postgres: Creation complete after 49s (ID: Z1MQRA7DJOWIOA_postgres.private_A)
module.vpc.aws_route53_record.redis: Still creating... (20s elapsed)
module.vpc.aws_route53_record.redis: Still creating... (30s elapsed)
module.vpc.aws_route53_record.redis: Still creating... (40s elapsed)
module.vpc.aws_route53_record.redis: Creation complete after 49s (ID: Z1MQRA7DJOWIOA_redis.private_CNAME)

Error: Error applying plan:

1 error(s) occurred:

* module.vpc.aws_route53_record.private-ns: 1 error(s) occurred:

* aws_route53_record.private-ns: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='private.', type='NS'] but it already exists]
	status code: 400, request id: 116279d4-3c4f-11e9-bf97-7b5cffa0e97a
```

